### PR TITLE
Fix bug related to new guids for saved worlds.

### DIFF
--- a/main/Boku/Scenes/InGame/InGameLoadSave.cs
+++ b/main/Boku/Scenes/InGame/InGameLoadSave.cs
@@ -542,18 +542,17 @@ namespace Boku
             {
                 UnDoStack.OverwriteTopOfStack();
 
-                //if a new name, at the very least we need a new guid
+                // If a new name, at the very least we need a new guid.
                 xmlWorldData.id = Guid.NewGuid();
             }
 
             // If we're saving the EmptyWorld we should generate a new guid.
-            string curWorldFileName = xmlWorldData.id.ToString() + ".Xml";
-            if (curWorldFileName == MiniHub.emptyWorldFileName)
+            if (MiniHub.Instance.newWorldDialog.IsNewWorld(xmlWorldData.id.ToString()))
             {
                 xmlWorldData.id = Guid.NewGuid();
             }
 
-            //if genres hasn't been populated yet, populate it with MyWorlds flag at least
+            // If genres hasn't been populated yet, populate it with MyWorlds flag.
             if (xmlWorldData.genres == 0)
             {
                 xmlWorldData.genres |= (int)Genres.MyWorlds;

--- a/main/Boku/Scenes/MiniHub.cs
+++ b/main/Boku/Scenes/MiniHub.cs
@@ -44,8 +44,6 @@ namespace Boku
     {
         public static MiniHub Instance = null;
 
-        public static string emptyWorldFileName = @"03a1b038-fd3f-492f-b18c-2a197fe68701.Xml";
-
         private Texture2D homeTexture = null;
 
         public NewWorldDialog newWorldDialog;
@@ -603,7 +601,7 @@ namespace Boku
             if (InGame.XmlWorldData != null)
             {
                 bool genreTest = ((int)InGame.XmlWorldData.genres & (int)Genres.MyWorlds) != 0;
-                bool newWorldTest = InGame.XmlWorldData.Filename == emptyWorldFileName;
+                bool newWorldTest = MiniHub.Instance.newWorldDialog.IsNewWorld(InGame.XmlWorldData.id.ToString());
                 if (genreTest && !newWorldTest)
                 {
                     isMyWorld = true;

--- a/main/Boku/Scenes/SaveLevelDialog.cs
+++ b/main/Boku/Scenes/SaveLevelDialog.cs
@@ -1143,6 +1143,12 @@ namespace Boku
             /// <param name="newName"></param>
             public void SaveLevelAndExit(bool newName, bool preserveLinks)
             {
+                // If name of world or creator has changed, force newName to true so we generate a new guid.
+                if (InGame.XmlWorldData.name != shared.CurNameScrubbed || InGame.XmlWorldData.creator != Auth.CreatorName)
+                {
+                    newName = true;
+                }
+
                 InGame.XmlWorldData.name = shared.CurNameScrubbed;
                 InGame.XmlWorldData.creator = Auth.CreatorName;
                 if (shared.curVersion != 0)

--- a/main/Boku/UI2D/NewWorldDialog.cs
+++ b/main/Boku/UI2D/NewWorldDialog.cs
@@ -358,6 +358,24 @@ namespace Boku.UI2D
             }
         }   // end of Render()
 
+        /// <summary>
+        /// Test whether the guid belongs to one of the new worlds.
+        /// </summary>
+        /// <param name="guid"></param>
+        /// <returns></returns>
+        public bool IsNewWorld(string guid)
+        {
+            foreach (NewWorldLevel level in levels)
+            {
+                if (0 == string.Compare(level.LevelGuid, guid, ignoreCase: true))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }   // end of IsNewWorld()
+
         #endregion
 
         #region Internal


### PR DESCRIPTION
Previously New World could be saved without having a new guid created for it which led to multiple levels with the same id.